### PR TITLE
Add sowing feature

### DIFF
--- a/src/Base/i18n/locales/en/appLayout.json
+++ b/src/Base/i18n/locales/en/appLayout.json
@@ -13,7 +13,8 @@
       "field": "Fields",
       "aplicator": "Aplicactors",
       "warehouse": "Warehouse",
-      "movements": "Movements"
+      "movements": "Movements",
+      "sowing": "Sowing"
     }
   }
 }

--- a/src/Base/i18n/locales/en/sowing.json
+++ b/src/Base/i18n/locales/en/sowing.json
@@ -1,0 +1,34 @@
+{
+  "actions": {
+    "create": "Add Sowing"
+  },
+  "datatable": {
+    "label": {
+      "description": "Description",
+      "hectares": "Hectares"
+    }
+  },
+  "create": {
+    "label": {
+      "description": "Description",
+      "hectares": "Hectares"
+    },
+    "title": "Add sowing",
+    "button": {
+      "submit": "Add sowing"
+    }
+  },
+  "toast": {
+    "create": {
+      "success": "Sowing added successfully"
+    }
+  },
+  "modal": {
+    "button": {
+      "buttonConfirm": "Confirm",
+      "buttonCancel": "Cancel"
+    },
+    "title": "Add new sowing",
+    "description": "Are you sure you want to add the sowing?"
+  }
+}

--- a/src/Base/i18n/locales/es/appLayout.json
+++ b/src/Base/i18n/locales/es/appLayout.json
@@ -13,7 +13,8 @@
       "field": "Campos",
       "aplicator": "Aplicadores",
       "warehouse": "Almacén",
-      "movements": "Movimientos"
+      "movements": "Movimientos",
+      "sowing": "Siembra"
     }
   }
 }

--- a/src/Base/i18n/locales/es/sowing.json
+++ b/src/Base/i18n/locales/es/sowing.json
@@ -1,0 +1,34 @@
+{
+  "actions": {
+    "create": "Agregar siembra"
+  },
+  "datatable": {
+    "label": {
+      "description": "Descripción",
+      "hectares": "Hectáreas"
+    }
+  },
+  "create": {
+    "label": {
+      "description": "Descripción",
+      "hectares": "Hectáreas"
+    },
+    "title": "Añadir siembra",
+    "button": {
+      "submit": "Añadir siembra"
+    }
+  },
+  "toast": {
+    "create": {
+      "success": "Siembra agregada con exito"
+    }
+  },
+  "modal": {
+    "button": {
+      "buttonConfirm": "Confirmar",
+      "buttonCancel": "Cancelar"
+    },
+    "title": "Añadir nueva siembra",
+    "description": "¿Esta seguro que desea añadir la siembra?"
+  }
+}

--- a/src/Base/layout/AppLayout.tsx
+++ b/src/Base/layout/AppLayout.tsx
@@ -50,6 +50,11 @@ const AppLayout = ({ children }: PropsWithChildren) => {
       path: "/movements",
       icon: BriefcaseIcon,
     },
+    {
+      title: t("sidebar.menu.sowing"),
+      path: "/sowing",
+      icon: BriefcaseIcon,
+    },
   ];
 
   return (

--- a/src/Sowing/components/ConfirmCreateDialog.tsx
+++ b/src/Sowing/components/ConfirmCreateDialog.tsx
@@ -1,0 +1,49 @@
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from "@chakra-ui/react";
+import { useTranslation } from "Base/i18n";
+
+interface ConfirmCreateDialogProps {
+  isOpen: boolean;
+  isLoading: boolean;
+  title: string;
+  description: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const ConfirmCreateDialog = ({
+  isOpen,
+  isLoading,
+  title,
+  description,
+  onClose,
+  onConfirm,
+}: ConfirmCreateDialogProps) => {
+  const { t } = useTranslation("sowing");
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>{title}</ModalHeader>
+        <ModalBody>{description}</ModalBody>
+        <ModalFooter>
+          <Button mr={3} onClick={onClose} variant="ghost">
+            {t("modal.button.buttonCancel")}
+          </Button>
+          <Button colorScheme="main" isLoading={isLoading} onClick={onConfirm}>
+            {t("modal.button.buttonConfirm")}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default ConfirmCreateDialog;

--- a/src/Sowing/components/index.ts
+++ b/src/Sowing/components/index.ts
@@ -1,0 +1,1 @@
+export { default as ConfirmCreateDialog } from "./ConfirmCreateDialog";

--- a/src/Sowing/data/SowingRepository/client.ts
+++ b/src/Sowing/data/SowingRepository/client.ts
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+const sowingClient = axios.create({
+  baseURL: `${process.env.NEXT_PUBLIC_API_URL}/sowing`,
+});
+
+export default sowingClient;

--- a/src/Sowing/data/SowingRepository/createSowingRepository.ts
+++ b/src/Sowing/data/SowingRepository/createSowingRepository.ts
@@ -1,0 +1,17 @@
+import sowingClient from "./client";
+import createSowing from "./services/createSowing";
+import getAllSowing from "./services/getAllSowing";
+import { SowingRepository } from "./types";
+
+const createSowingRepository = (userToken: string): SowingRepository => {
+  sowingClient.defaults.headers.common = {
+    Authorization: `Bearer ${userToken}`,
+  };
+
+  return {
+    createSowing,
+    getAllSowing,
+  };
+};
+
+export default createSowingRepository;

--- a/src/Sowing/data/SowingRepository/hooks/index.ts
+++ b/src/Sowing/data/SowingRepository/hooks/index.ts
@@ -1,0 +1,2 @@
+export { default as useAllSowingService } from "./useAllSowingService";
+export { default as useCreateSowingService } from "./useCreateSowingService";

--- a/src/Sowing/data/SowingRepository/hooks/useAllSowingService.ts
+++ b/src/Sowing/data/SowingRepository/hooks/useAllSowingService.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
+import { TokenHandler } from "@kushitech/auth-module";
+import FetchActionTypes from "Base/types/FetchActionTypes";
+import createSowingRepository from "../createSowingRepository";
+import listSowingReducer, { initialState } from "../reducer/listSowingReducer";
+
+const useAllSowingService = () => {
+  const [invalidated, setInvalidateCache] = useState<boolean | undefined>();
+
+  const repository = useMemo(
+    () => createSowingRepository(TokenHandler.getTokenFromCookies() || ""),
+    []
+  );
+  const [{ data: sowingList, loading, error }, dispatch] = useReducer(
+    listSowingReducer,
+    initialState
+  );
+
+  const invalidateCache = useCallback(() => setInvalidateCache(true), []);
+
+  useEffect(() => {
+    if (invalidated || invalidated === undefined) {
+      dispatch({ type: FetchActionTypes.Start });
+      repository
+        .getAllSowing()
+        .then((data) => {
+          dispatch({ type: FetchActionTypes.Succeess, payload: data });
+        })
+        .catch((e) => {
+          dispatch({ type: FetchActionTypes.Failure, payload: e.message });
+        });
+    }
+  }, [invalidated, repository]);
+
+  useEffect(() => {
+    if (invalidated) {
+      setInvalidateCache(false);
+    }
+  }, [invalidated]);
+
+  return { sowingList, loading, error, invalidateCache };
+};
+
+export default useAllSowingService;

--- a/src/Sowing/data/SowingRepository/hooks/useCreateSowingService.ts
+++ b/src/Sowing/data/SowingRepository/hooks/useCreateSowingService.ts
@@ -1,0 +1,40 @@
+import { useCallback, useReducer, useMemo } from "react";
+import { TokenHandler } from "@kushitech/auth-module";
+import FetchActionTypes from "Base/types/FetchActionTypes";
+import createSowingRepository from "../createSowingRepository";
+import createSowingReducer, {
+  initialState,
+} from "../reducer/createSowingReducer";
+
+const useCreateSowingService = () => {
+  const repository = useMemo(
+    () => createSowingRepository(TokenHandler.getTokenFromCookies() || ""),
+    []
+  );
+  const [{ data, loading, error }, dispatch] = useReducer(
+    createSowingReducer,
+    initialState
+  );
+
+  const createSowing = useCallback(
+    (body) =>
+      repository.createSowing(body).then((res) => {
+        dispatch({ type: FetchActionTypes.Succeess, payload: res });
+        return res;
+      }),
+    [repository]
+  );
+
+  const startFetch = useCallback(
+    () => dispatch({ type: FetchActionTypes.Start }),
+    []
+  );
+  const failureFetch = useCallback(
+    (err: string) => dispatch({ type: FetchActionTypes.Failure, payload: err }),
+    []
+  );
+
+  return { data, loading, error, createSowing, startFetch, failureFetch };
+};
+
+export default useCreateSowingService;

--- a/src/Sowing/data/SowingRepository/index.ts
+++ b/src/Sowing/data/SowingRepository/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export { default as createSowingRepository } from "./createSowingRepository";

--- a/src/Sowing/data/SowingRepository/reducer/createSowingReducer.ts
+++ b/src/Sowing/data/SowingRepository/reducer/createSowingReducer.ts
@@ -1,0 +1,40 @@
+import BaseAction from "Base/types/BaseAction";
+import FetchActionTypes from "Base/types/FetchActionTypes";
+import FetchPayload from "Base/types/FetchPayload";
+import { Sowing } from "../types";
+
+export type CreateSowingActions = BaseAction<FetchPayload<Sowing>>;
+
+type CreateSowingAction = CreateSowingActions[keyof CreateSowingActions];
+
+interface CreateSowingState {
+  data?: Sowing;
+  loading: boolean;
+  error?: string;
+}
+
+export const initialState: CreateSowingState = {
+  loading: false,
+};
+
+const createSowingReducer = (
+  state: CreateSowingState = initialState,
+  action: CreateSowingAction
+): CreateSowingState => {
+  switch (action.type) {
+    case FetchActionTypes.Start: {
+      return { ...state, loading: true };
+    }
+    case FetchActionTypes.Succeess: {
+      return { ...state, loading: false, data: action.payload };
+    }
+    case FetchActionTypes.Failure: {
+      return { ...state, loading: false, error: action.payload };
+    }
+    default: {
+      return state;
+    }
+  }
+};
+
+export default createSowingReducer;

--- a/src/Sowing/data/SowingRepository/reducer/listSowingReducer.ts
+++ b/src/Sowing/data/SowingRepository/reducer/listSowingReducer.ts
@@ -1,0 +1,55 @@
+import BaseAction from "Base/types/BaseAction";
+import FetchActionTypes from "Base/types/FetchActionTypes";
+import FetchPayload from "Base/types/FetchPayload";
+import { Sowing } from "../types";
+
+type ListSowingPayload = FetchPayload<Sowing[]>;
+
+export type ListSowingActions = BaseAction<ListSowingPayload>;
+
+type ListSowingAction = ListSowingActions[keyof ListSowingActions];
+
+interface ListSowingState {
+  data: Sowing[];
+  loading: boolean;
+  error?: string;
+}
+
+export const initialState: ListSowingState = {
+  data: [],
+  loading: false,
+};
+
+const listSowingReducer = (
+  state: ListSowingState = initialState,
+  action: ListSowingAction
+): ListSowingState => {
+  switch (action.type) {
+    case FetchActionTypes.Start: {
+      return {
+        ...state,
+        loading: true,
+      };
+    }
+    case FetchActionTypes.Succeess: {
+      return {
+        ...state,
+        loading: false,
+        data: action.payload,
+      };
+    }
+    case FetchActionTypes.Failure: {
+      return {
+        ...state,
+        data: initialState.data,
+        error: action.payload,
+        loading: false,
+      };
+    }
+    default: {
+      return state;
+    }
+  }
+};
+
+export default listSowingReducer;

--- a/src/Sowing/data/SowingRepository/services/createSowing.ts
+++ b/src/Sowing/data/SowingRepository/services/createSowing.ts
@@ -1,0 +1,17 @@
+import { isAxiosError } from "axios";
+import { CreateSowingSchema } from "Sowing/schemas/createSowingSchema";
+import sowingClient from "../client";
+
+const createSowing = async (body: CreateSowingSchema) => {
+  try {
+    const response = await sowingClient.post("/create", body);
+    return response.data;
+  } catch (error) {
+    if (isAxiosError(error)) {
+      throw new Error(error.response?.data.message ?? error.message);
+    }
+    throw new Error("Unknown error");
+  }
+};
+
+export default createSowing;

--- a/src/Sowing/data/SowingRepository/services/getAllSowing.ts
+++ b/src/Sowing/data/SowingRepository/services/getAllSowing.ts
@@ -1,0 +1,17 @@
+import { isAxiosError } from "axios";
+import sowingClient from "../client";
+import { Sowing } from "../types";
+
+const getAllSowing = async (): Promise<Sowing[]> => {
+  try {
+    const response = await sowingClient.get("/");
+    return response.data;
+  } catch (error) {
+    if (isAxiosError(error)) {
+      throw new Error(error.response?.data.message ?? error.message);
+    }
+    throw new Error("Unknown error");
+  }
+};
+
+export default getAllSowing;

--- a/src/Sowing/data/SowingRepository/types/index.ts
+++ b/src/Sowing/data/SowingRepository/types/index.ts
@@ -1,0 +1,12 @@
+import { CreateSowingSchema } from "Sowing/schemas/createSowingSchema";
+
+export interface Sowing {
+  description: string;
+  hectares: number;
+  id: number;
+}
+
+export interface SowingRepository {
+  createSowing: (body: CreateSowingSchema) => Promise<Sowing>;
+  getAllSowing: () => Promise<Sowing[]>;
+}

--- a/src/Sowing/features/CreateSowing.tsx
+++ b/src/Sowing/features/CreateSowing.tsx
@@ -1,0 +1,89 @@
+import { Button, useDisclosure, useToast } from "@chakra-ui/react";
+import { useTranslation } from "Base/i18n";
+import { useForm } from "react-hook-form";
+import FormPageLayout from "Base/layout/FormPageLayout";
+import FormContainerLayout from "Base/layout/FormContainerLayout";
+import FormSectionLayout from "Base/layout/FormSectionLayout";
+import { FormInputText, FormInputNumber, StatusCard } from "Base/components";
+import ConfirmCreateModal from "Sowing/components/ConfirmCreateDialog";
+import createSowingSchema, {
+  CreateSowingSchema,
+} from "Sowing/schemas/createSowingSchema";
+import { zodResolver } from "@hookform/resolvers/zod";
+import useCreateSowingService from "Sowing/data/SowingRepository/hooks/useCreateSowingService";
+
+interface CreateSowingProps {
+  navigateToSowing: () => void;
+}
+
+const CreateSowing = ({ navigateToSowing }: CreateSowingProps) => {
+  const { t } = useTranslation("sowing");
+  const toast = useToast();
+  const { handleSubmit, register, watch } = useForm<CreateSowingSchema>({
+    resolver: zodResolver(createSowingSchema),
+    defaultValues: { description: "", hectares: 0 },
+  });
+
+  const { createSowing, loading, error, startFetch, failureFetch } =
+    useCreateSowingService();
+  const { isOpen, onClose, onOpen } = useDisclosure();
+
+  const onSubmit = (data: CreateSowingSchema) => {
+    startFetch();
+    createSowing(data)
+      .then(() => {
+        toast({ status: "success", description: t("toast.create.success") });
+        navigateToSowing();
+      })
+      .catch((e) => failureFetch(e.message));
+  };
+
+  return (
+    <FormPageLayout onSubmit={handleSubmit(onSubmit)}>
+      <FormContainerLayout>
+        <FormSectionLayout>
+          <FormInputText
+            isRequired
+            id="description"
+            label={t("create.label.description")}
+            name="description"
+            inputProps={register("description")}
+          />
+          <FormInputNumber
+            isRequired
+            id="hectares"
+            label={t("create.label.hectares")}
+            name="hectares"
+            inputProps={register("hectares", { valueAsNumber: true })}
+          />
+        </FormSectionLayout>
+        <FormSectionLayout>
+          {watch("description") && (
+            <StatusCard
+              label={watch("description")}
+              value={<>{watch("hectares")} ha</>}
+            />
+          )}
+        </FormSectionLayout>
+        <Button
+          colorScheme="main"
+          isLoading={loading}
+          onClick={onOpen}
+          type="button"
+        >
+          {t("create.button.submit")}
+        </Button>
+        <ConfirmCreateModal
+          description={t("modal.description")}
+          isLoading={loading}
+          isOpen={isOpen}
+          title={t("modal.title")}
+          onClose={onClose}
+          onConfirm={handleSubmit(onSubmit)}
+        />
+      </FormContainerLayout>
+    </FormPageLayout>
+  );
+};
+
+export default CreateSowing;

--- a/src/Sowing/features/SowingHeader.tsx
+++ b/src/Sowing/features/SowingHeader.tsx
@@ -1,0 +1,26 @@
+import { Button, Flex, Heading, Icon } from "@chakra-ui/react";
+import { PlusIcon } from "@heroicons/react/24/outline";
+import { useTranslation } from "react-i18next";
+
+interface SowingHeaderProps {
+  navigateToCreateSowing: () => void;
+}
+
+const SowingHeader = ({ navigateToCreateSowing }: SowingHeaderProps) => {
+  const { t } = useTranslation(["sowing", "appLayout"]);
+
+  return (
+    <Flex justify="space-between">
+      <Heading>{t("sidebar.menu.sowing", { ns: "appLayout" })}</Heading>
+      <Button
+        leftIcon={<Icon as={PlusIcon} />}
+        variant="outline"
+        onClick={navigateToCreateSowing}
+      >
+        {t("actions.create")}
+      </Button>
+    </Flex>
+  );
+};
+
+export default SowingHeader;

--- a/src/Sowing/features/SowingList.tsx
+++ b/src/Sowing/features/SowingList.tsx
@@ -1,0 +1,45 @@
+import { useCallback, useMemo } from "react";
+import DataTable, { BaseColumn } from "Base/components/DataTable";
+import { Sowing, useAllSowingService } from "Sowing/data/SowingRepository";
+
+interface SowingListProps {
+  navigateToDetails: (sowingId: number) => void;
+}
+
+const SowingList = ({ navigateToDetails }: SowingListProps) => {
+  const { loading, sowingList } = useAllSowingService();
+
+  const columns: BaseColumn<Sowing>[] = useMemo(
+    () => [
+      {
+        label: "id",
+        selector: (row) => row.id,
+      },
+      {
+        label: "Descripcion",
+        selector: (row) => row.description,
+      },
+      {
+        label: "Hectareas",
+        selector: (row) => row.hectares,
+      },
+    ],
+    []
+  );
+
+  const handleClick = useCallback(
+    (row: Sowing) => navigateToDetails(row.id),
+    [navigateToDetails]
+  );
+
+  return (
+    <DataTable
+      columns={columns}
+      data={sowingList}
+      loading={loading}
+      onClickRow={handleClick}
+    />
+  );
+};
+
+export default SowingList;

--- a/src/Sowing/features/index.ts
+++ b/src/Sowing/features/index.ts
@@ -1,0 +1,3 @@
+export { default as CreateSowing } from "./CreateSowing";
+export { default as SowingHeader } from "./SowingHeader";
+export { default as SowingList } from "./SowingList";

--- a/src/Sowing/hooks/index.ts
+++ b/src/Sowing/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "../data/SowingRepository/hooks";

--- a/src/Sowing/index.ts
+++ b/src/Sowing/index.ts
@@ -1,0 +1,3 @@
+export * from "./features";
+export * from "./hooks";
+export * from "./data/SowingRepository";

--- a/src/Sowing/schemas/createSowingSchema.ts
+++ b/src/Sowing/schemas/createSowingSchema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const createSowingSchema = z.object({
+  description: z.string(),
+  hectares: z
+    .number({ invalid_type_error: "Required" })
+    .positive("mustBePositive"),
+});
+
+export type CreateSowingSchema = z.infer<typeof createSowingSchema>;
+
+export default createSowingSchema;

--- a/src/pages/sowing/create.tsx
+++ b/src/pages/sowing/create.tsx
@@ -1,0 +1,42 @@
+import { useCallback } from "react";
+import { useRouter } from "next/router";
+import { Heading } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+import PageLayout from "Base/layout/PageLayout";
+import { CreateSowing } from "Sowing/features";
+import { withAuth } from "@kushitech/auth-module";
+import { User } from "Auth/types";
+
+const SowingCreatePage = () => {
+  const { t } = useTranslation("sowing");
+  const router = useRouter();
+
+  const navigateToSowing = useCallback(() => router.push("/sowing"), [router]);
+  return (
+    <PageLayout>
+      {{
+        header: <Heading>{t("create.title")}</Heading>,
+        content: <CreateSowing navigateToSowing={navigateToSowing} />,
+      }}
+    </PageLayout>
+  );
+};
+
+export const getServerSideProps = withAuth<User>(async (ctx, user) => {
+  if (user.role === "USER") {
+    console.log("You dont have permission on :>> ", ctx.resolvedUrl);
+    return {
+      redirect: {
+        permanent: false,
+        destination: `/`,
+      },
+    };
+  }
+  return {
+    props: {
+      user,
+    },
+  };
+});
+
+export default SowingCreatePage;

--- a/src/pages/sowing/index.tsx
+++ b/src/pages/sowing/index.tsx
@@ -1,0 +1,32 @@
+import { useCallback } from "react";
+import { useRouter } from "next/router";
+
+import PageLayout from "Base/layout/PageLayout";
+import { SowingHeader, SowingList } from "Sowing/features";
+
+const SowingPage = () => {
+  const router = useRouter();
+
+  const navigateToCreateSowing = useCallback(
+    () => router.push("/sowing/create"),
+    [router]
+  );
+
+  const navigateToDetails = useCallback(
+    (sowingId: number) => router.push(`/sowing/${sowingId}`),
+    [router]
+  );
+
+  return (
+    <PageLayout>
+      {{
+        header: (
+          <SowingHeader navigateToCreateSowing={navigateToCreateSowing} />
+        ),
+        content: <SowingList navigateToDetails={navigateToDetails} />,
+      }}
+    </PageLayout>
+  );
+};
+
+export default SowingPage;


### PR DESCRIPTION
## Summary
- add sowing translations
- include sowing option in the sidebar
- implement sowing data repository and hooks
- add Sowing feature components
- create pages for sowing list and create

## Testing
- `npx prettier --write "src/**/*.{ts,tsx,js,jsx,json,css,md}"`
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68430ae362e48320b75943de279781bd