### PR TITLE
Add seeding movement

### DIFF
--- a/src/Movements/features/CreateSeedingMovement.tsx
+++ b/src/Movements/features/CreateSeedingMovement.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useState } from "react";
+import { Controller, FieldErrors, useFormContext } from "react-hook-form";
+import { Button, useDisclosure, useToast } from "@chakra-ui/react";
+import { useTranslation } from "Base/i18n";
+import useCreateMovementsStates from "Movements/hooks/useCreateMovementsStates";
+import { useCreateMovementsService } from "Movements/data/MovementsRepository";
+import FormPageLayout from "Base/layout/FormPageLayout";
+import FormContainerLayout from "Base/layout/FormContainerLayout";
+import FormSectionLayout from "Base/layout/FormSectionLayout";
+import ConfirmCreateModal from "Movements/components/ConfirmCreateDialog";
+import FormCreateAplicationDetails from "./FormCreateAplicationDetails";
+import { CreateAplicationSchema } from "Movements/schemas/CreateAplicationSchema";
+import { FormInputText, FormSelect } from "Base/components";
+import useWareHouseOptions from "Movements/hooks/useWareHouseOptions";
+import useAplicatorOptions from "Movements/hooks/useAplicatorOptions";
+import useFieldOptions from "Movements/hooks/useFieldOptions";
+import useBatchOptions from "Movements/hooks/useBatchOptions";
+import FormInputNumber from "Base/components/FormInputNumber";
+
+interface CreateMovementsProps {
+  navigateToMovements: () => void;
+}
+
+const CreateSeedingMovement = ({
+  navigateToMovements,
+}: CreateMovementsProps) => {
+  const toast = useToast();
+  const { t } = useTranslation("movements");
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+    register,
+    reset,
+    watch,
+  } = useFormContext<CreateAplicationSchema>();
+
+  const { options: warehouseOptions, loading: warehouseLoading } =
+    useWareHouseOptions();
+  const { options: aplicatorOptions, loading: aplicatorLoading } =
+    useAplicatorOptions();
+  const { options: fieldOptions, loading: fieldLoading } = useFieldOptions();
+  const { options: batchOptions, loading: batchLoading } = useBatchOptions();
+
+  const { loading, error, startFetch, successFetch, failureFetch } =
+    useCreateMovementsStates();
+  const { isOpen, onClose, onOpen } = useDisclosure({ defaultIsOpen: false });
+  const { createMovements } = useCreateMovementsService();
+
+  const [filteredBatchOptions, setFilteredBatchOptions] =
+    useState(batchOptions);
+
+  const fieldId = watch("fieldId");
+
+  useEffect(() => {
+    if (fieldId) {
+      const newBatchOptions = batchOptions.filter(
+        (batch) => batch.fieldId === fieldId.value
+      );
+      setFilteredBatchOptions(newBatchOptions);
+    } else {
+      setFilteredBatchOptions(batchOptions);
+    }
+  }, [fieldId, batchOptions]);
+
+  const handleCreateMovements = (data: CreateAplicationSchema) => {
+    console.log("startFetch :>> ", data);
+    startFetch();
+
+    createMovements({
+      stockMovementDetail: data.stockMovementDetail.map((detail) => ({
+        quantity: detail.quantity,
+        productId: detail.product.id,
+      })),
+      date: new Date(),
+      description: data.description,
+      movementType: data.movementType,
+      aplicatorId: data.aplicatorId.value,
+      warehouseOriginId: data.warehouseOriginId.value,
+      batchId: data.batchId.value,
+      value: data.value,
+    })
+      .then((movementsCreated) => {
+        reset();
+        successFetch(movementsCreated);
+        toast({
+          status: "success",
+          description: ` ${"Creado correctamente"} `,
+        });
+        onClose();
+        navigateToMovements();
+      })
+      .catch((e) => {
+        const errorMessage = e.response.data.message;
+        failureFetch(errorMessage);
+      });
+  };
+
+  const handleSubmitError = (errors: FieldErrors<CreateAplicationSchema>) => {
+    console.log("errors :>> ", errors);
+  };
+
+  useEffect(() => {
+    if (error) {
+      toast({ status: "error", description: error });
+    }
+  }, [error, toast]);
+
+  return (
+    <FormPageLayout onSubmit={handleSubmit(handleCreateMovements)}>
+      <FormContainerLayout>
+        <FormSectionLayout>
+          <Controller
+            control={control}
+            name="warehouseOriginId"
+            render={({ field }) => (
+              <FormSelect
+                ref={field.ref}
+                isRequired
+                errorMessage={
+                  errors.warehouseOriginId?.message
+                    ? "Debe seleccionar un deposito de origen"
+                    : undefined
+                }
+                isLoading={warehouseLoading}
+                label={"Deposito de origen"}
+                name={field.name}
+                options={warehouseOptions}
+                value={
+                  field.value &&
+                  "value" in field.value &&
+                  field.value.value !== null
+                    ? field.value
+                    : null
+                }
+                onChange={field.onChange}
+              />
+            )}
+          />
+
+          <Controller
+            control={control}
+            name="aplicatorId"
+            render={({ field }) => (
+              <FormSelect
+                ref={field.ref}
+                isRequired
+                errorMessage={
+                  errors.aplicatorId?.message
+                    ? "Debe seleccionar un aplicador"
+                    : undefined
+                }
+                isLoading={aplicatorLoading}
+                label={"Aplicador"}
+                name={field.name}
+                options={aplicatorOptions}
+                value={
+                  field.value &&
+                  "value" in field.value &&
+                  field.value.value !== null
+                    ? field.value
+                    : null
+                }
+                onChange={field.onChange}
+              />
+            )}
+          />
+
+          <Controller
+            control={control}
+            name="fieldId"
+            render={({ field }) => (
+              <FormSelect
+                ref={field.ref}
+                isRequired
+                errorMessage={
+                  errors.fieldId?.message
+                    ? "Debe seleccionar un campo"
+                    : undefined
+                }
+                isLoading={fieldLoading}
+                label={"Campo"}
+                name={field.name}
+                options={fieldOptions}
+                value={
+                  field.value &&
+                  "value" in field.value &&
+                  field.value.value !== null
+                    ? field.value
+                    : null
+                }
+                onChange={field.onChange}
+              />
+            )}
+          />
+
+          <Controller
+            control={control}
+            name="batchId"
+            render={({ field }) => (
+              <FormSelect
+                ref={field.ref}
+                isRequired
+                errorMessage={
+                  errors.batchId?.message
+                    ? "Debe seleccionar un lote"
+                    : undefined
+                }
+                isLoading={batchLoading}
+                label={"Lote"}
+                name={field.name}
+                options={filteredBatchOptions}
+                value={
+                  field.value &&
+                  "value" in field.value &&
+                  field.value.value !== null
+                    ? field.value
+                    : null
+                }
+                onChange={field.onChange}
+              />
+            )}
+          />
+
+          <FormInputText
+            isRequired
+            errorMessage={
+              errors.description
+                ? (t(`errors.${errors.description.message}`, {
+                    ns: "common",
+                  }) as string)
+                : undefined
+            }
+            id="description"
+            label={"Descripcion de la siembra"}
+            name="description"
+            inputProps={{ ...register("description") }}
+          />
+          <FormInputNumber
+            isRequired
+            control={control}
+            errorMessage={
+              errors.value
+                ? (t(`errors.${errors.value.message}`, {
+                    ns: "common",
+                  }) as string)
+                : undefined
+            }
+            id="value"
+            label={"Valor aproximado de la siembra"}
+            leftIcon="$"
+            name="value"
+            thousandSeparator="."
+            // type=""
+          />
+        </FormSectionLayout>
+
+        <FormCreateAplicationDetails />
+
+        <Button colorScheme="main" isLoading={loading} onClick={onOpen}>
+          {"Confirmar siembra"}
+        </Button>
+        <ConfirmCreateModal
+          description={"confirm button"}
+          isLoading={loading}
+          isOpen={isOpen}
+          title={"Confirmar"}
+          onClose={onClose}
+          onConfirm={handleSubmit(handleCreateMovements, handleSubmitError)}
+        />
+      </FormContainerLayout>
+    </FormPageLayout>
+  );
+};
+
+export default CreateSeedingMovement;

--- a/src/Movements/features/MovementDetails.tsx
+++ b/src/Movements/features/MovementDetails.tsx
@@ -46,7 +46,11 @@ const MovementDetails = ({ movement }: MovementDetailsProps) => {
             colorScheme={getMovementTypeColor(movement?.movementType)}
             fontSize={{ md: "md" }}
           >
-            {movement?.movementType == "BUY" ? " COMPRA " : " APLICACION "}
+            {movement?.movementType === "BUY"
+              ? "COMPRA"
+              : movement?.movementType === "SEEDING"
+              ? "SIEMBRA"
+              : "APLICACION"}
           </Badge>
         </Heading>
         <Stack direction={{ base: "column" }} mt={4} spacing={2}>

--- a/src/Movements/features/MovementsHeader.tsx
+++ b/src/Movements/features/MovementsHeader.tsx
@@ -6,12 +6,14 @@ interface MovementsHeaderProps {
   navigateToCreateBuyMovement: () => void;
   navigateToCreateAplication: () => void;
   navigateToCreateWithdraw: () => void;
+  navigateToCreateSeeding: () => void;
 }
 
 const MovementsHeader = ({
   navigateToCreateBuyMovement,
   navigateToCreateAplication,
   navigateToCreateWithdraw,
+  navigateToCreateSeeding,
 }: MovementsHeaderProps) => {
   const { t } = useTranslation(["movements"]);
 
@@ -38,6 +40,14 @@ const MovementsHeader = ({
           onClick={navigateToCreateAplication}
         >
           {"Generar aplicacion"}
+        </Button>
+        <Button
+          leftIcon={<Icon as={PlusIcon} />}
+          mr="2"
+          variant="outline"
+          onClick={navigateToCreateSeeding}
+        >
+          {"Registrar siembra"}
         </Button>
       </Stack>
     </Stack>

--- a/src/Movements/features/index.ts
+++ b/src/Movements/features/index.ts
@@ -1,3 +1,4 @@
 export { default as CreateBuyMovement } from "./CreateBuyMovement";
 export { default as MovementsHeader } from "./MovementsHeader";
 export { default as MovementsList } from "./MovementsList";
+export { default as CreateSeedingMovement } from "./CreateSeedingMovement";

--- a/src/Movements/utils/getMovementTypeColor.ts
+++ b/src/Movements/utils/getMovementTypeColor.ts
@@ -8,6 +8,9 @@ export default function getMovementTypeColor(
     case "APLICATION": {
       return "yellow";
     }
+    case "SEEDING": {
+      return "purple";
+    }
     case "RENDITION": {
       return "red";
     }

--- a/src/pages/movements/create-seeding.tsx
+++ b/src/pages/movements/create-seeding.tsx
@@ -1,0 +1,57 @@
+import { useCallback } from "react";
+import { useRouter } from "next/router";
+import { useForm, FormProvider, useFieldArray } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Heading } from "@chakra-ui/react";
+
+import createAplicationSchema, {
+  CreateAplicationSchema,
+} from "Movements/schemas/CreateAplicationSchema";
+import PageLayout from "Base/layout/PageLayout";
+import CreateAplicationProvider from "Movements/contexts/CreateBuyContext/CreateAplicationProvider";
+import CreateSeedingMovement from "Movements/features/CreateSeedingMovement";
+
+const SeedingCreatePage = () => {
+  const router = useRouter();
+  const methods = useForm<CreateAplicationSchema>({
+    resolver: zodResolver(createAplicationSchema),
+    //remover hardcodeo
+    defaultValues: {
+      movementType: "SEEDING",
+      stockMovementDetail: [],
+      warehouseOriginId: {},
+    },
+  });
+
+  const navigateToMovements = useCallback(
+    () => router.push("/movements"),
+    [router]
+  );
+
+  const stockMovementsArrayMethods = useFieldArray({
+    control: methods.control, // control props comes from useForm (optional: if you are using FormContext)
+    name: "stockMovementDetail", // unique name for your Field Array
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <CreateAplicationProvider
+        {...methods}
+        stockMovementDetail={stockMovementsArrayMethods}
+      >
+        <PageLayout>
+          {{
+            header: (
+              <Heading>{"Completar los datos para la siembra"}</Heading>
+            ),
+            content: (
+              <CreateSeedingMovement navigateToMovements={navigateToMovements} />
+            ),
+          }}
+        </PageLayout>
+      </CreateAplicationProvider>
+    </FormProvider>
+  );
+};
+
+export default SeedingCreatePage;

--- a/src/pages/movements/index.tsx
+++ b/src/pages/movements/index.tsx
@@ -23,6 +23,11 @@ const MovementsPage = () => {
     [router]
   );
 
+  const navigateToCreateSeeding = useCallback(
+    () => router.push("/movements/create-seeding"),
+    [router]
+  );
+
   const navigateToDetails = useCallback(
     (movementId: number) => router.push(`/movements/${movementId}`),
     [router]
@@ -36,6 +41,7 @@ const MovementsPage = () => {
             navigateToCreateBuyMovement={navigateToCreateBuyMovement}
             navigateToCreateAplication={navigateToCreateAplication}
             navigateToCreateWithdraw={navigateToCreateWithdraw}
+            navigateToCreateSeeding={navigateToCreateSeeding}
           />
         ),
         content: <MovementsList navigateToDetails={navigateToDetails} />,


### PR DESCRIPTION
## Summary
- implement create seeding page and movement component
- add seeding button in MovementsHeader
- support seeding color badge

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471fa46fbc8320bee2966709a331c6